### PR TITLE
Fix order allow deny

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source $(pwd)/.env
 
+aws ec2 describe-addresses | jq -r '.Addresses[] | [.PublicIp, .InstanceId] | @tsv' | awk '{print "allow",$1"/32;","# Instance-ID:"$2}'
 curl -s https://ip-ranges.amazonaws.com/ip-ranges.json | jq -r '.prefixes[].ip_prefix' | awk '{print "deny",$1";","#From AWS"}'
 
 # https://cloud.google.com/compute/docs/faq#ipranges
@@ -9,4 +10,3 @@ for LINE in `dig txt _cloud-netblocks.googleusercontent.com +short | tr " " "\n"
 do
   dig txt $LINE +short
 done | tr " " "\n" | sed '/ip4/s/$/; #From GCP/' | grep ip4  | cut -f 2 -d : | sort -n | sed '/From/s/^/deny /'
-aws ec2 describe-addresses | jq -r '.Addresses[] | [.PublicIp, .InstanceId] | @tsv' | awk '{print "allow",$1"/32;","# Instance-ID:"$2}'


### PR DESCRIPTION
## Overview
Fix Access not permitted

see.
http://nginx.org/en/docs/http/ngx_http_access_module.html
> The rules are checked in sequence until the first match is found. In this example, access is allowed only for IPv4 networks 10.1.1.0/16 and 192.168.1.0/24 excluding the address 192.168.1.1, and for IPv6 network 2001:0db8::/32. In case of a lot of rules, the use of the ngx_http_geo_module module variables is preferable.